### PR TITLE
TD-38 Upgrade for PHP7.2 & Symfony ^4.4-^5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,32 +4,31 @@ on: push
 
 jobs:
     test:
-        name: Test (PHP ${{ matrix.php-version }} on ${{ matrix.operating-system }})
+        name: Test (PHP ${{ matrix.php-version }})
 
         strategy:
             fail-fast: false
             matrix:
-                php-version: ['7.0', '7.2', '7.3']
-                operating-system: ['ubuntu-16.04', 'ubuntu-18.04']
+                php-version: ['7.2', '7.3', '7.4']
 
-        runs-on: ${{ matrix.operating-system }}
+        runs-on: ubuntu-18.04
 
         steps:
             -   name: Checkout
                 uses: actions/checkout@v2
 
             -   name: Setup PHP
-                uses: shivammathur/setup-php@v1
+                uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php-version }}
-                    coverage: xdebug
+                    coverage: pcov
 
             -   name: Cache Dependencies
                 uses: actions/cache@v1
                 with:
                     path: ~/.composer/cache
-                    key: ${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}
-                    restore-keys: ${{ matrix.operating-system }}-php${{ matrix.php-version }}-composer-
+                    key: php${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}
+                    restore-keys: php${{ matrix.php-version }}-composer-
 
             -   name: Install Dependencies
                 run: composer install --no-ansi --no-interaction --no-progress --no-suggest --prefer-dist
@@ -44,7 +43,7 @@ jobs:
                     echo "::set-env name=COVERAGE::${COVERAGE}"
 
             -   name: Psalm
-                run: vendor/bin/psalm --shepherd
+                run: vendor/bin/psalm  --output-format=github --shepherd
 
             -   name: Report PR Status
                 uses: actions/github-script@0.4.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
 .phpcs-cache
+.phpunit.result.cache
 composer.lock
 vendor

--- a/composer.json
+++ b/composer.json
@@ -15,21 +15,21 @@
         }
     },
     "require": {
-        "php": "^7.0",
+        "php": "^7.2",
         "ext-json": "*",
         "psr/http-message": "^1.0",
         "laminas/laminas-diactoros": "^1.8",
         "ircmaxell/random-lib": "^1.2",
-        "symfony/lock": "^3.4"
+        "symfony/lock": "^4.4 || ^5.0"
     },
     "config": {
         "platform": {
-            "php": "7.0.33"
+            "php": "7.2.24"
         }
     },
     "require-dev": {
-        "myonlinestore/coding-standard": "^1.0",
-        "vimeo/psalm": "^3.2",
-        "phpunit/phpunit": "^6.5"
+        "myonlinestore/coding-standard": "^2.0",
+        "vimeo/psalm": "^3.11",
+        "phpunit/phpunit": "^8.5"
     }
 }

--- a/src/DateTime/DateTimeFactory.php
+++ b/src/DateTime/DateTimeFactory.php
@@ -8,9 +8,9 @@ interface DateTimeFactory
     /**
      * @deprecated Use createImmutable()
      */
-    public function create(string $time = 'now', \DateTimeZone $timezone = null): \DateTime;
+    public function create(string $time = 'now', ?\DateTimeZone $timezone = null): \DateTime;
 
-    public function createImmutable(string $time = 'now', \DateTimeZone $timezone = null): \DateTimeImmutable;
+    public function createImmutable(string $time = 'now', ?\DateTimeZone $timezone = null): \DateTimeImmutable;
 
     public function createImmutableFromFormat(string $format, string $time): \DateTimeImmutable;
 

--- a/src/Infrastructure/DateTime/PhpDateTimeFactory.php
+++ b/src/Infrastructure/DateTime/PhpDateTimeFactory.php
@@ -7,18 +7,22 @@ use MyOnlineStore\Common\Factory\DateTime\DateTimeFactory;
 
 final class PhpDateTimeFactory implements DateTimeFactory
 {
-    public function create(string $time = 'now', \DateTimeZone $timezone = null): \DateTime
+    public function create(string $time = 'now', ?\DateTimeZone $timezone = null): \DateTime
     {
         return new \DateTime($time, $timezone);
     }
 
-    public function createImmutable(string $time = 'now', \DateTimeZone $timezone = null): \DateTimeImmutable
+    public function createImmutable(string $time = 'now', ?\DateTimeZone $timezone = null): \DateTimeImmutable
     {
         return new \DateTimeImmutable($time, $timezone);
     }
 
+    /**
+     * @psalm-suppress InvalidFalsableReturnType
+     */
     public function createImmutableFromFormat(string $format, string $time): \DateTimeImmutable
     {
+        /** @psalm-suppress FalsableReturnStatement */
         return \DateTimeImmutable::createFromFormat($format, $time);
     }
 

--- a/src/Infrastructure/Locking/SymfonyBlockingLockFactoryProvider.php
+++ b/src/Infrastructure/Locking/SymfonyBlockingLockFactoryProvider.php
@@ -3,20 +3,20 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Factory\Infrastructure\Locking;
 
-use Symfony\Component\Lock\Factory;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\RetryTillSaveStore;
-use Symfony\Component\Lock\StoreInterface;
 
 final class SymfonyBlockingLockFactoryProvider implements SymfonyLockFactoryProvider
 {
-    const INTERVAL = 100;
+    private const INTERVAL = 100;
 
-    public function getFactory(StoreInterface $store, int $timeout = 0): Factory
+    public function getFactory(PersistingStoreInterface $store, int $timeout = 0): LockFactory
     {
         if (0 < $timeout) {
             $store = new RetryTillSaveStore($store, self::INTERVAL, (int) \ceil($timeout / self::INTERVAL));
         }
 
-        return new Factory($store);
+        return new LockFactory($store);
     }
 }

--- a/src/Infrastructure/Locking/SymfonyLockFactoryProvider.php
+++ b/src/Infrastructure/Locking/SymfonyLockFactoryProvider.php
@@ -3,13 +3,13 @@ declare(strict_types=1);
 
 namespace MyOnlineStore\Common\Factory\Infrastructure\Locking;
 
-use Symfony\Component\Lock\Factory;
-use Symfony\Component\Lock\StoreInterface;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\PersistingStoreInterface;
 
 interface SymfonyLockFactoryProvider
 {
     /**
      * @param int $timeout Number of milliseconds to wait for lock
      */
-    public function getFactory(StoreInterface $store, int $timeout = 0): Factory;
+    public function getFactory(PersistingStoreInterface $store, int $timeout = 0): LockFactory;
 }

--- a/src/Infrastructure/Locking/SymfonyLockProvider.php
+++ b/src/Infrastructure/Locking/SymfonyLockProvider.php
@@ -8,7 +8,7 @@ use MyOnlineStore\Common\Factory\Locking\LockProvider;
 use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\LockInterface;
-use Symfony\Component\Lock\StoreInterface;
+use Symfony\Component\Lock\PersistingStoreInterface;
 
 final class SymfonyLockProvider implements LockProvider
 {
@@ -22,21 +22,18 @@ final class SymfonyLockProvider implements LockProvider
      */
     private $locks = [];
 
-    /** @var StoreInterface */
+    /** @var PersistingStoreInterface */
     private $storage;
 
     public function __construct(
         SymfonyLockFactoryProvider $lockFactoryProvider,
-        StoreInterface $storage
+        PersistingStoreInterface $storage
     ) {
         $this->lockFactoryProvider = $lockFactoryProvider;
         $this->storage = $storage;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function acquire(string $name, int $timeout = 10)
+    public function acquire(string $name, int $timeout = 10): void
     {
         if (isset($this->locks[$name])) {
             throw new LockNotAcquirable(\sprintf('Lock "%s" was already acquired', $name));
@@ -70,7 +67,7 @@ final class SymfonyLockProvider implements LockProvider
         return \array_keys($this->locks);
     }
 
-    public function release(string $name)
+    public function release(string $name): void
     {
         if (!isset($this->locks[$name])) {
             return;

--- a/src/Locking/LockProvider.php
+++ b/src/Locking/LockProvider.php
@@ -8,7 +8,7 @@ interface LockProvider
     /**
      * @throws LockNotAcquirable
      */
-    public function acquire(string $name, int $timeout = 10);
+    public function acquire(string $name, int $timeout = 10): void;
 
     /**
      * Returns the names of all acquired locks within this runtime
@@ -17,5 +17,5 @@ interface LockProvider
      */
     public function getAcquiredLockNames(): array;
 
-    public function release(string $name);
+    public function release(string $name): void;
 }

--- a/src/Locking/Strategy/Strategy.php
+++ b/src/Locking/Strategy/Strategy.php
@@ -5,7 +5,7 @@ namespace MyOnlineStore\Common\Factory\Locking\Strategy;
 
 interface Strategy
 {
-    const DEFAULT_DURATION = 10;
+    public const DEFAULT_DURATION = 10;
 
     public function getLockName(): string;
 

--- a/src/Random/TokenGenerator.php
+++ b/src/Random/TokenGenerator.php
@@ -5,7 +5,7 @@ namespace MyOnlineStore\Common\Factory\Random;
 
 interface TokenGenerator
 {
-    const DEFAULT_CHARACTERS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    public const DEFAULT_CHARACTERS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 
     public function generate(int $size): string;
 

--- a/tests/Infrastructure/DateTime/PhpDateTimeFactoryTest.php
+++ b/tests/Infrastructure/DateTime/PhpDateTimeFactoryTest.php
@@ -11,12 +11,12 @@ final class PhpDateTimeFactoryTest extends TestCase
     /** @var PhpDateTimeFactory */
     private $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->factory = new PhpDateTimeFactory();
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $time = '2011-11-11';
         $dateTimeZone = new \DateTimeZone('Europe/Amsterdam');
@@ -27,7 +27,7 @@ final class PhpDateTimeFactoryTest extends TestCase
         );
     }
 
-    public function testCreateImmutable()
+    public function testCreateImmutable(): void
     {
         $time = '2011-11-11';
         $dateTimeZone = new \DateTimeZone('Europe/Amsterdam');
@@ -38,7 +38,7 @@ final class PhpDateTimeFactoryTest extends TestCase
         );
     }
 
-    public function testCreateImmutableFromFormat()
+    public function testCreateImmutableFromFormat(): void
     {
         self::assertEquals(
             \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2018-11-06 14:00:00'),
@@ -46,7 +46,7 @@ final class PhpDateTimeFactoryTest extends TestCase
         );
     }
 
-    public function testCreateImmutableFromMutable()
+    public function testCreateImmutableFromMutable(): void
     {
         $dateTime = new \DateTime('2011-11-11', new \DateTimeZone('Europe/Amsterdam'));
 

--- a/tests/Infrastructure/Http/LaminasResponseFactoryTest.php
+++ b/tests/Infrastructure/Http/LaminasResponseFactoryTest.php
@@ -16,21 +16,21 @@ final class LaminasResponseFactoryTest extends TestCase
     /** @var LaminasResponseFactory */
     private $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->factory = new LaminasResponseFactory(
             $this->streamFactory = $this->createMock(StreamFactory::class)
         );
     }
 
-    public function testCreateResponseWillReturnInstanceOfResponseWithGivenStatusCode()
+    public function testCreateResponseWillReturnInstanceOfResponseWithGivenStatusCode(): void
     {
         $statusCode = 201;
 
         self::assertSame($statusCode, $this->factory->createResponse($statusCode)->getStatusCode());
     }
 
-    public function testCreateResponseFromStringWithBodyOnlyWillReturnInstanceOfResponse()
+    public function testCreateResponseFromStringWithBodyOnlyWillReturnInstanceOfResponse(): void
     {
         $this->streamFactory->expects(self::once())
             ->method('createFromString')
@@ -44,7 +44,7 @@ final class LaminasResponseFactoryTest extends TestCase
         self::assertSame([], $response->getHeaders());
     }
 
-    public function testCreateResponseFromStringWithBodyAndStatusCodeOnlyWillReturnInstanceOfResponse()
+    public function testCreateResponseFromStringWithBodyAndStatusCodeOnlyWillReturnInstanceOfResponse(): void
     {
         $stream = $this->createMock(StreamInterface::class);
 
@@ -60,7 +60,7 @@ final class LaminasResponseFactoryTest extends TestCase
         self::assertEquals([], $response->getHeaders());
     }
 
-    public function testCreateResponseFromStringWillReturnInstanceOfResponse()
+    public function testCreateResponseFromStringWillReturnInstanceOfResponse(): void
     {
         $this->streamFactory->expects(self::once())
             ->method('createFromString')
@@ -74,7 +74,7 @@ final class LaminasResponseFactoryTest extends TestCase
         self::assertSame(['foo' => ['bar']], $response->getHeaders());
     }
 
-    public function testCreateJsonResponseWillReturnInstanceOfResponse()
+    public function testCreateJsonResponseWillReturnInstanceOfResponse(): void
     {
         $data = ['foo' => 'bar'];
         $response = $this->factory->createJsonResponse($data, 203);
@@ -83,7 +83,7 @@ final class LaminasResponseFactoryTest extends TestCase
         self::assertSame(203, $response->getStatusCode());
     }
 
-    public function testCreateRedirectResponseWillReturnInstanceOfResponseWithGivenStatusCode()
+    public function testCreateRedirectResponseWillReturnInstanceOfResponseWithGivenStatusCode(): void
     {
         $response = $this->factory->createRedirectResponse(
             $uri = 'http://foobar.baz',

--- a/tests/Infrastructure/Http/LaminasStreamFactoryTest.php
+++ b/tests/Infrastructure/Http/LaminasStreamFactoryTest.php
@@ -11,12 +11,12 @@ final class LaminasStreamFactoryTest extends TestCase
     /** @var LaminasStreamFactory */
     private $factory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->factory = new LaminasStreamFactory();
     }
 
-    public function testCreateFromStringWillReturnStream()
+    public function testCreateFromStringWillReturnStream(): void
     {
         $stream = $this->factory->createFromString('test');
 

--- a/tests/Infrastructure/Locking/SymfonyLockProviderTest.php
+++ b/tests/Infrastructure/Locking/SymfonyLockProviderTest.php
@@ -9,16 +9,16 @@ use MyOnlineStore\Common\Factory\Locking\LockNotAcquirable;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
-use Symfony\Component\Lock\Factory;
+use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
-use Symfony\Component\Lock\StoreInterface;
+use Symfony\Component\Lock\PersistingStoreInterface;
 
 final class SymfonyLockProviderTest extends TestCase
 {
     /** @var LockInterface */
     private $lock;
 
-    /** @var Factory */
+    /** @var LockFactory */
     private $lockFactory;
 
     /** @var SymfonyLockFactoryProvider */
@@ -27,18 +27,18 @@ final class SymfonyLockProviderTest extends TestCase
     /** @var SymfonyLockProvider */
     private $lockProvider;
 
-    /** @var StoreInterface */
+    /** @var PersistingStoreInterface */
     private $storage;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->lockProvider = new SymfonyLockProvider(
             $this->lockFactoryProvider = $this->createMock(SymfonyLockFactoryProvider::class),
-            $this->storage = $this->createMock(StoreInterface::class)
+            $this->storage = $this->createMock(PersistingStoreInterface::class)
         );
 
         $this->lock = $this->createMock(LockInterface::class);
-        $this->lockFactory = $this->createMock(Factory::class);
+        $this->lockFactory = $this->createMock(LockFactory::class);
     }
 
     public function blockingTimoutDataProvider(): \Generator
@@ -48,7 +48,7 @@ final class SymfonyLockProviderTest extends TestCase
         yield [-1, false];
     }
 
-    public function testGetAcquiredLockNames()
+    public function testGetAcquiredLockNames(): void
     {
         $lockName = 'foo';
 
@@ -59,7 +59,7 @@ final class SymfonyLockProviderTest extends TestCase
         self::assertEquals([$lockName], $this->lockProvider->getAcquiredLockNames());
     }
 
-    public function testGetWillThrowExceptionIfLockIsConflicted()
+    public function testGetWillThrowExceptionIfLockIsConflicted(): void
     {
         $this->expectException(LockNotAcquirable::class);
 
@@ -81,7 +81,7 @@ final class SymfonyLockProviderTest extends TestCase
         $this->lockProvider->acquire('foo');
     }
 
-    public function testGetWillThrowExceptionIfLockAcquireFailsWithAnException()
+    public function testGetWillThrowExceptionIfLockAcquireFailsWithAnException(): void
     {
         $this->expectException(LockNotAcquirable::class);
 
@@ -103,7 +103,7 @@ final class SymfonyLockProviderTest extends TestCase
         $this->lockProvider->acquire('foo');
     }
 
-    public function testGetWillThrowExceptionIfLockCannotBeAcquired()
+    public function testGetWillThrowExceptionIfLockCannotBeAcquired(): void
     {
         $this->expectException(LockNotAcquirable::class);
 
@@ -124,9 +124,8 @@ final class SymfonyLockProviderTest extends TestCase
 
     /**
      * @dataProvider blockingTimoutDataProvider
-     *
      */
-    public function testGetWillAcquireLock(int $timeout, bool $blocking)
+    public function testGetWillAcquireLock(int $timeout, bool $blocking): void
     {
         $this->lockFactoryProvider->expects(self::once())
             ->method('getFactory')
@@ -143,7 +142,7 @@ final class SymfonyLockProviderTest extends TestCase
         $this->lockProvider->acquire('foo', $timeout);
     }
 
-    public function testGetWillThrowExceptionIfLockHasBeenAcquiredInSameRuntime()
+    public function testGetWillThrowExceptionIfLockHasBeenAcquiredInSameRuntime(): void
     {
         $this->expectException(LockNotAcquirable::class);
 
@@ -163,7 +162,7 @@ final class SymfonyLockProviderTest extends TestCase
         $this->lockProvider->acquire('foo', 0);
     }
 
-    public function testReleaseWillDoNothingIfLockWasNotAcquired()
+    public function testReleaseWillDoNothingIfLockWasNotAcquired(): void
     {
         $this->lockFactoryProvider->expects(self::once())
             ->method('getFactory')
@@ -182,7 +181,7 @@ final class SymfonyLockProviderTest extends TestCase
         $this->lockProvider->release('bar');
     }
 
-    public function testReleaseWillReleaseAcquiredLock()
+    public function testReleaseWillReleaseAcquiredLock(): void
     {
         $this->lockFactoryProvider->expects(self::once())
             ->method('getFactory')

--- a/tests/Infrastructure/Random/RandomLibTokenGeneratorTest.php
+++ b/tests/Infrastructure/Random/RandomLibTokenGeneratorTest.php
@@ -15,14 +15,14 @@ final class RandomLibTokenGeneratorTest extends TestCase
     /** @var Generator */
     private $mockGenerator;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->generator = new RandomLibTokenGenerator(
             $this->mockGenerator = $this->createMock(Generator::class)
         );
     }
 
-    public function testGenerate()
+    public function testGenerate(): void
     {
         $this->mockGenerator->expects(self::once())
             ->method('generate')
@@ -32,7 +32,7 @@ final class RandomLibTokenGeneratorTest extends TestCase
         self::assertSame('foobar', $this->generator->generate(5));
     }
 
-    public function testGenerateInt()
+    public function testGenerateInt(): void
     {
         $this->mockGenerator->expects(self::once())
             ->method('generateInt')
@@ -42,7 +42,7 @@ final class RandomLibTokenGeneratorTest extends TestCase
         self::assertSame(7, $this->generator->generateInt(5, 10));
     }
 
-    public function testGenerateString()
+    public function testGenerateString(): void
     {
         $this->mockGenerator->expects(self::once())
             ->method('generateString')

--- a/tests/Locking/Strategy/FixedTest.php
+++ b/tests/Locking/Strategy/FixedTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class FixedTest extends TestCase
 {
-    public function testGetters()
+    public function testGetters(): void
     {
         $strategy = new Fixed(
             $lockName = 'foo',
@@ -20,7 +20,7 @@ final class FixedTest extends TestCase
         self::assertSame($lockDuration, $strategy->getLockDuration());
     }
 
-    public function testDefaultLockDuration()
+    public function testDefaultLockDuration(): void
     {
         self::assertSame(Strategy::DEFAULT_DURATION, (new Fixed('foo'))->getLockDuration());
     }


### PR DESCRIPTION
Notable changes:
- `Symfony\Component\Lock\StoreInterface` is deprecated and replaced by `Symfony\Component\Lock\PersistingStoreInterface`
- `Symfony\Component\Lock\Factory` is deprecated and replaced by `Symfony\Component\Lock\Factory\LockFactory `

Should be released as new major version due to the breaking Symfony deprecations.