### PR TITLE
add possibility to add additional headers and encoding options when creating a JsonResponse

### DIFF
--- a/src/Http/ResponseFactory.php
+++ b/src/Http/ResponseFactory.php
@@ -24,9 +24,15 @@ interface ResponseFactory
     ): ResponseInterface;
 
     /**
-     * @param mixed $data
+     * @param mixed    $data
+     * @param string[] $headers
      */
-    public function createJsonResponse($data, int $statusCode = 200): ResponseInterface;
+    public function createJsonResponse(
+        $data,
+        int $statusCode = 200,
+        array $headers = [],
+        int $encodingOptions = \JSON_UNESCAPED_UNICODE
+    ): ResponseInterface;
 
     /**
      * @param string|UriInterface $uri

--- a/src/Infrastructure/Http/LaminasResponseFactory.php
+++ b/src/Infrastructure/Http/LaminasResponseFactory.php
@@ -49,9 +49,13 @@ final class LaminasResponseFactory implements ResponseFactory
     /**
      * @inheritDoc
      */
-    public function createJsonResponse($data, int $statusCode = 200): ResponseInterface
-    {
-        return new JsonResponse($data, $statusCode);
+    public function createJsonResponse(
+        $data,
+        int $statusCode = 200,
+        array $headers = [],
+        int $encodingOptions = \JSON_UNESCAPED_UNICODE
+    ): ResponseInterface {
+        return new JsonResponse($data, $statusCode, $headers, $encodingOptions);
     }
 
     /**

--- a/tests/Infrastructure/Http/LaminasResponseFactoryTest.php
+++ b/tests/Infrastructure/Http/LaminasResponseFactoryTest.php
@@ -10,17 +10,90 @@ use Psr\Http\Message\StreamInterface;
 
 final class LaminasResponseFactoryTest extends TestCase
 {
-    /** @var StreamFactory */
-    private $streamFactory;
-
     /** @var LaminasResponseFactory */
     private $factory;
+
+    /** @var StreamFactory */
+    private $streamFactory;
 
     protected function setUp(): void
     {
         $this->factory = new LaminasResponseFactory(
             $this->streamFactory = $this->createMock(StreamFactory::class)
         );
+    }
+
+    public function testCreateJsonResponseWillReturnInstanceOfResponse(): void
+    {
+        $data = ['foo' => 'Twoich wyborów'];
+        $headers = ['qux' => 'lax'];
+        $response = $this->factory->createJsonResponse($data, 203, $headers, \JSON_PARTIAL_OUTPUT_ON_ERROR);
+
+        self::assertSame($data, \json_decode($response->getBody()->getContents(), true));
+        self::assertSame(203, $response->getStatusCode());
+        self::assertEquals(['qux' => ['lax'], 'content-type' => ['application/json']], $response->getHeaders());
+    }
+
+    public function testCreateRedirectResponseWillReturnInstanceOfResponseWithGivenStatusCode(): void
+    {
+        $response = $this->factory->createRedirectResponse(
+            $uri = 'http://foobar.baz',
+            $statusCode = 303
+        );
+
+        self::assertSame($statusCode, $response->getStatusCode());
+        self::assertSame([$uri], $response->getHeader('location'));
+    }
+
+    public function testCreateResponseFromStringWillReturnInstanceOfResponse(): void
+    {
+        $this->streamFactory->expects(self::once())
+            ->method('createFromString')
+            ->with('test')
+            ->willReturn($stream = $this->createMock(StreamInterface::class));
+
+        $response = $this->factory->createResponseFromString('test', 204, ['foo' => 'bar']);
+
+        self::assertSame($stream, $response->getBody());
+        self::assertSame(204, $response->getStatusCode());
+        self::assertSame(['foo' => ['bar']], $response->getHeaders());
+    }
+
+    public function testCreateResponseFromStringWithBodyAndStatusCodeOnlyWillReturnInstanceOfResponse(): void
+    {
+        $stream = $this->createMock(StreamInterface::class);
+
+        $this->streamFactory->expects(self::once())
+            ->method('createFromString')
+            ->with('test')
+            ->willReturn($stream);
+
+        $response = $this->factory->createResponseFromString('test', 204);
+
+        self::assertSame($stream, $response->getBody());
+        self::assertEquals(204, $response->getStatusCode());
+        self::assertEquals([], $response->getHeaders());
+    }
+
+    public function testCreateResponseFromStringWithBodyOnlyWillReturnInstanceOfResponse(): void
+    {
+        $this->streamFactory->expects(self::once())
+            ->method('createFromString')
+            ->with('test')
+            ->willReturn($stream = $this->createMock(StreamInterface::class));
+
+        $response = $this->factory->createResponseFromString('test');
+
+        self::assertSame($stream, $response->getBody());
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame([], $response->getHeaders());
+    }
+
+    public function testCreateResponseWillReturnInstanceOfResponseWithGivenStatusCode(): void
+    {
+        $statusCode = 201;
+
+        self::assertSame($statusCode, $this->factory->createResponse($statusCode)->getStatusCode());
     }
 
     public function testCreatesApiProblemResponse(): void
@@ -63,76 +136,5 @@ final class LaminasResponseFactoryTest extends TestCase
             \json_decode($response->getBody()->getContents(), true)
         );
         self::assertSame(456, $response->getStatusCode());
-    }
-
-    public function testCreateResponseWillReturnInstanceOfResponseWithGivenStatusCode(): void
-    {
-        $statusCode = 201;
-
-        self::assertSame($statusCode, $this->factory->createResponse($statusCode)->getStatusCode());
-    }
-
-    public function testCreateResponseFromStringWithBodyOnlyWillReturnInstanceOfResponse(): void
-    {
-        $this->streamFactory->expects(self::once())
-            ->method('createFromString')
-            ->with('test')
-            ->willReturn($stream = $this->createMock(StreamInterface::class));
-
-        $response = $this->factory->createResponseFromString('test');
-
-        self::assertSame($stream, $response->getBody());
-        self::assertSame(200, $response->getStatusCode());
-        self::assertSame([], $response->getHeaders());
-    }
-
-    public function testCreateResponseFromStringWithBodyAndStatusCodeOnlyWillReturnInstanceOfResponse(): void
-    {
-        $stream = $this->createMock(StreamInterface::class);
-
-        $this->streamFactory->expects(self::once())
-            ->method('createFromString')
-            ->with('test')
-            ->willReturn($stream);
-
-        $response = $this->factory->createResponseFromString('test', 204);
-
-        self::assertSame($stream, $response->getBody());
-        self::assertEquals(204, $response->getStatusCode());
-        self::assertEquals([], $response->getHeaders());
-    }
-
-    public function testCreateResponseFromStringWillReturnInstanceOfResponse(): void
-    {
-        $this->streamFactory->expects(self::once())
-            ->method('createFromString')
-            ->with('test')
-            ->willReturn($stream = $this->createMock(StreamInterface::class));
-
-        $response = $this->factory->createResponseFromString('test', 204, ['foo' => 'bar']);
-
-        self::assertSame($stream, $response->getBody());
-        self::assertSame(204, $response->getStatusCode());
-        self::assertSame(['foo' => ['bar']], $response->getHeaders());
-    }
-
-    public function testCreateJsonResponseWillReturnInstanceOfResponse(): void
-    {
-        $data = ['foo' => 'bar'];
-        $response = $this->factory->createJsonResponse($data, 203);
-
-        self::assertSame($data, \json_decode($response->getBody()->getContents(), true));
-        self::assertSame(203, $response->getStatusCode());
-    }
-
-    public function testCreateRedirectResponseWillReturnInstanceOfResponseWithGivenStatusCode(): void
-    {
-        $response = $this->factory->createRedirectResponse(
-            $uri = 'http://foobar.baz',
-            $statusCode = 303
-        );
-
-        self::assertSame($statusCode, $response->getStatusCode());
-        self::assertSame([$uri], $response->getHeader('location'));
     }
 }


### PR DESCRIPTION
### This PR:

Corrects the mistakingly omitted `\JSON_UNESCAPED_UNICODE` when encoding JSON. 

##### Summary
- [x] Appropriate documentation has been written (check if not applicable).

**Breaking changes** 🔥
- non utf-8 text will no longer be encoded to unicode

**Backwards compatible additions** ✨
None

**Bugfixes/Changed internals** 🎈
https://myonlinestore.atlassian.net/browse/BIER-2310